### PR TITLE
Added New Changes to BinarySearchTree

### DIFF
--- a/data-structures-csharp/data-structures-csharp/BinarySearchTree/Node.cs
+++ b/data-structures-csharp/data-structures-csharp/BinarySearchTree/Node.cs
@@ -45,8 +45,9 @@ namespace DataStructures.BinarySearchTreeSpace
             {
                 Contract.Requires<ArgumentNullException>(key != null);
                 Contract.Requires<ArgumentNullException>(val != null);
-                Contract.Requires(parent != null);
-
+                //Removed the code because it throws error when we add the root Item (First item) where parent would be null
+               // Contract.Requires(parent != null);
+                this.key = key;
                 this.val = val;
                 Parent = parent;
                 Left = null;


### PR DESCRIPTION
Added changes to BinarySearchTree.  
Following things are modified under this change.
1. Changed the BinarySearchTree to Partial class
2. Modified Contract of Add, so that if the same is added twice it just updates the value rather than adding a new Node
3. Changed the FindSplitNode- Node is considered to be correct when there is difference between start and end is less and greater respectively.
4. Modified GetAllNodes- Now the function will return all the nodes in In-Order format
5. Modified GetAllNodes in Range- Now the function will return all the nodes within the range in In-Order Traversal.